### PR TITLE
Fixing incorrect tabbing to allow for CSV generation

### DIFF
--- a/Tools/sdlog2/sdlog2_dump.py
+++ b/Tools/sdlog2/sdlog2_dump.py
@@ -153,8 +153,8 @@ class SDLog2Parser:
                         first_data_msg = False
                     self.__parseMsg(msg_descr)
             bytes_read += self.__ptr
-        if not self.__debug_out and self.__time_msg != None and self.__csv_updated:
-            self.__printCSVRow()
+            if not self.__debug_out and self.__time_msg != None and self.__csv_updated:
+                self.__printCSVRow()
         f.close()
     
     def __bytesLeft(self):


### PR DESCRIPTION
The script was not working as desired, i.e., only generating one instance of data in resulting output file, rather than iterating through entire log file. Culprit determined to be incorrect indentation for two lines (i.e., should be included in the while loop)

Minor fix to correct the indentation error.
