### PR TITLE
hmc5883: Fix for Issue1858 detection of MAG on Int/Ext I2C Bus.

### DIFF
--- a/src/drivers/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/hmc5883/hmc5883_i2c.cpp
@@ -113,11 +113,17 @@ HMC5883_I2C::ioctl(unsigned operation, unsigned &arg)
 	switch (operation) {
 
 	case MAGIOCGEXTERNAL:
+// On PX4v1 the MAG can be on an internal I2C
+// On everything else its always external
+#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
 		if (_bus == PX4_I2C_BUS_EXPANSION) {
 			return 1;
 		} else {
 			return 0;
 		}
+#else
+                return 1;
+#endif
 
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);


### PR DESCRIPTION
This is to resolve Issue 1858
https://github.com/diydrones/ardupilot/issues/1858
On PX4v1 boards the MAG can be on an internal I2C bus.  On all other boards its always external.  This makes sure that is detected correctly.  
Thanks to Tridge for the assist!