### PR TITLE
sdlog2: Added 'd' type to FORMAT_TO_STRUCT.

### DIFF
--- a/Tools/sdlog2/sdlog2_dump.py
+++ b/Tools/sdlog2/sdlog2_dump.py
@@ -46,6 +46,7 @@ class SDLog2Parser:
         "h": ("h", None),
         "H": ("H", None),
         "i": ("i", None),
+        "d": ("d", None),
         "I": ("I", None),
         "f": ("f", None),
         "n": ("4s", None),


### PR DESCRIPTION
Fixes an exception we had been having when using sdlog2_dump.py
with dataflash logs:

Exception: Unsupported format char: d in message GRAW (171)