### PR TITLE
Add a system command for writing/viewing OTP, see docs below...

### DIFF
--- a/src/modules/systemlib/otp.c
+++ b/src/modules/systemlib/otp.c
@@ -104,30 +104,9 @@ int write_otp(uint8_t id_type, uint32_t vid, uint32_t pid, char *signature)
 	return errors;
 }
 
-int lock_otp(void)
+int lock_otp(int blocknum)
 {
-	//determine the required locking size - can only write full lock bytes */
-//	int size = sizeof(struct otp) / 32;
-//
-//	struct otp_lock otp_lock_mem;
-//
-//	memset(&otp_lock_mem, OTP_LOCK_UNLOCKED, sizeof(otp_lock_mem));
-//	for (int i = 0; i < sizeof(otp_lock_mem) / sizeof(otp_lock_mem.lock_bytes[0]); i++)
-//		otp_lock_mem.lock_bytes[i] = OTP_LOCK_LOCKED;
-	//XXX add the actual call here to write the OTP_LOCK bytes only at final stage
-	// val_copy(lock_ptr, &otp_lock_mem, sizeof(otp_lock_mem));
-
-	int locksize = 5;
-
-	int errors = 0;
-
-	// or just realise it's exctly 5x 32byte blocks we need to lock.  1 block for ID,type,vid,pid, and 4 blocks for certificate, which is 128 bytes.
-	for (int i = 0 ; i < locksize ; i++) {
-		if (F_write_byte(ADDR_OTP_LOCK_START + i, OTP_LOCK_LOCKED))
-			errors++;
-	}
-
-	return errors;
+    return F_write_byte(ADDR_OTP_LOCK_START + blocknum, OTP_LOCK_LOCKED);
 }
 
 

--- a/src/modules/systemlib/otp.h
+++ b/src/modules/systemlib/otp.h
@@ -51,7 +51,8 @@ __BEGIN_DECLS
 #define OTP_LOCK_LOCKED			0x00
 #define OTP_LOCK_UNLOCKED		0xFF
 
-
+#define OTP_NUM_BLOCKS          16
+#define OTP_BLOCK_SIZE          32
 
 #include <unistd.h>
 #include <stdint.h>
@@ -91,7 +92,8 @@ typedef struct {
 #define F_KEY2 ((unsigned long)0xCDEF89AB)
 #define IS_F_ADDRESS(ADDRESS) ((((ADDRESS) >= 0x08000000) && ((ADDRESS) < 0x080FFFFF)) || (((ADDRESS) >= 0x1FFF7800) && ((ADDRESS) < 0x1FFF7A0F)))
 
-
+#define F_OTP_BLOCK_PTR(blocknum) ((volatile uint8_t *) (ADDR_OTP_START + OTP_BLOCK_SIZE * (blocknum)))
+#define F_OTP_IS_LOCKED(blocknum) (((volatile uint8_t *) ADDR_OTP_LOCK_START)[blocknum] == 0)
 
 #pragma pack(push, 1)
 
@@ -141,7 +143,7 @@ __EXPORT void F_lock(void);
 __EXPORT int val_read(void *dest, volatile const void *src, int bytes);
 __EXPORT int val_write(volatile void *dest, const void *src, int bytes);
 __EXPORT int write_otp(uint8_t id_type, uint32_t vid, uint32_t pid, char *signature);
-__EXPORT int lock_otp(void);
+__EXPORT int lock_otp(int blocknum);
 
 
 __EXPORT int F_write_byte(unsigned long Address, uint8_t Data);

--- a/src/systemcmds/otp/README.txt
+++ b/src/systemcmds/otp/README.txt
@@ -1,0 +1,96 @@
+
+nsh> otp
+otp: usage:
+otp show - show all block contents and lock bitsotp write <blocknum> <32 hex bytes, LSB first, no spaces> <crc32 for bytes> - will print values after readback
+otp read <blocknum> - will print 32 bytes readback from block (and the current CRC)
+otp lock <blocknum> <blocknum> - will permanently lock the specified block number
+
+# show is intended to be human readable
+nsh> otp show
+ 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+ 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
+ 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
+ 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
+ 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
+ 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+10: U 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
+11: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+
+# the readback for writing to block 10 failed (OTP bits can _only_ be changed to zero)
+# even if unlocked there is NO WAY to change the back to a one.  So be careful even
+# if testing
+nsh> otp write 10 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+otp: Write not accepted
+
+# Because of this, we check a crc32 that must be included with each write command
+# if wrong we will not do the write
+nsh> otp write 10 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea67
+otp: CRC does not match bytes
+
+# The _only_ response that indicates success is WRITTEN
+# This demonstrates writing ffs
+nsh> otp write 11 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+WRITTEN
+
+# This demonstrates writing some other string of bytes
+nsh> otp write 11 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+WRITTEN
+
+# See the happy bytes now on block 11
+nsh> otp show
+ 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+ 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
+ 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
+ 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
+ 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
+ 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+10: U 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
+11: U 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+
+# To prevent locking incorrect blocks, the block number must be given twice
+nsh> otp lock 10
+otp: Invalid arguments
+otp: usage:
+otp show - show all block contents and lock bitsotp write <blocknum> <32 hex bytes, LSB first, no spaces> <crc32 for bytes> - will print values after readback
+otp read <blocknum> - will print 32 bytes readback from block (and the current CRC)
+otp lock <blocknum> <blocknum> - will permanently lock the specified block number
+
+# The _only_ response that indicates success for the lock command is LOCKED
+nsh> otp lock 10 10
+LOCKED
+
+# Notice that block 10 is now locked
+nsh> otp show
+ 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+ 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
+ 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
+ 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
+ 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
+ 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+ 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+10: L 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
+11: U 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
+12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
+nsh>

--- a/src/systemcmds/otp/module.mk
+++ b/src/systemcmds/otp/module.mk
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2012, 2013 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#
+# OTP program/read/lock utility.
+#
+
+MODULE_COMMAND		= otp
+SRCS			= otp.c
+
+MODULE_STACKSIZE	= 1800
+
+MAXOPTIMIZATION		= -Os

--- a/src/systemcmds/otp/otp.c
+++ b/src/systemcmds/otp/otp.c
@@ -1,0 +1,217 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 PX4 Development Team. All rights reserved.
+ *   Author: @author Kevin Hester <kevinh@geeksville.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file otp.c
+ * Tool for reading/writing/locking OTP
+ */
+
+#include <nuttx/config.h>
+#include <nuttx/sched.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <crc32.h>
+
+#include <systemlib/systemlib.h>
+#include <systemlib/err.h>
+#include <systemlib/otp.h>
+
+__EXPORT int otp_main(int argc, char *argv[]);
+
+
+
+static void
+usage(const char *reason)
+{
+	if (reason != NULL) {
+		warnx("%s", reason);
+	}
+
+	errx(1,
+	     "usage:\n"
+	     "otp show - show all block contents and lock bits"
+	     "otp write <blocknum> <32 hex bytes, LSB first, no spaces> <crc32 for bytes> - will print values after readback\n"
+	     "otp read <blocknum> - will print 32 bytes readback from block (and the current CRC)\n"
+	     "otp lock <blocknum> <blocknum> - will permanently lock the specified block number\n"
+	    );
+}
+
+static void otp_lock(int blocknum)
+{
+	F_unlock();
+	sched_lock();
+
+	lock_otp(blocknum);
+
+	F_lock();
+	sched_unlock();
+}
+
+static int otp_read(int i)
+{
+	printf("%2d: %c ", i, F_OTP_IS_LOCKED(i) ? 'L' : 'U');
+	volatile uint8_t *base = F_OTP_BLOCK_PTR(i);
+
+	for (int j = 0; j < OTP_BLOCK_SIZE; j++) {
+		printf("%02x", base[j]);
+		// if(j % 4 == 0) printf(" ");
+	}
+
+	printf(" %08x\n", crc32((const uint8_t *) base, OTP_BLOCK_SIZE));
+	return 0;
+}
+
+static int otp_show(void)
+{
+	for (int i = 0; i < OTP_NUM_BLOCKS; i++) {
+		otp_read(i);
+	}
+
+	return 0;
+}
+
+static int otp_write(int blocknum, const char *hexstr, uint32_t expectedcrc)
+{
+	if (strlen(hexstr) != OTP_BLOCK_SIZE * 2) {
+		errx(1, "Bad hex string length");
+		return 1;
+	}
+
+	uint8_t bytes[OTP_BLOCK_SIZE];
+
+	for (int i = 0; i < OTP_BLOCK_SIZE; i++) {
+		char temp[3];
+		temp[0] = hexstr[2 * i];
+		temp[1] = hexstr[2 * i + 1];
+		temp[2] = '\0';
+		bytes[i] = (uint8_t) strtol(temp, NULL, 16);
+	}
+
+	if (crc32(bytes, OTP_BLOCK_SIZE) != expectedcrc) {
+		errx(1, "CRC does not match bytes");
+		return 1;
+	}
+
+	F_unlock();
+	sched_lock();
+
+	volatile uint8_t *base = F_OTP_BLOCK_PTR(blocknum);
+
+	for (int i = 0; i < OTP_BLOCK_SIZE; i++) {
+		if (F_write_byte(ADDR_OTP_START + OTP_BLOCK_SIZE * blocknum + i, bytes[i])) {
+			errx(1, "Failed to write");
+			return 1;
+		}
+
+		if (base[i] != bytes[i]) {
+			errx(1, "Write not accepted");
+			return 1;
+		}
+	}
+
+	F_lock();
+	sched_unlock();
+
+	printf("WRITTEN\n");
+	return 0;
+}
+
+int otp_main(int argc, char *argv[])
+{
+	int getblocknum(int argnum) {
+		if (argnum >= argc) {
+			errx(1, "must specify a block number");
+			return -1;
+
+		} else {
+			int bnum = -1;
+			sscanf(argv[argnum], "%d", &bnum);
+
+			if (bnum < 0 || bnum >= OTP_NUM_BLOCKS) {
+				errx(1, "invalid block number");
+				return -1;
+
+			} else {
+				return bnum;
+			}
+		}
+	}
+
+	if (argc < 2) {
+		usage(NULL);
+
+	} else {
+		const char *cmd = argv[1];
+
+		if (!strcmp(cmd, "show")) {
+			return otp_show();
+
+		} else if (!strcmp(cmd, "read") && argc == 3) {
+			int bnum = getblocknum(2);
+
+			if (bnum >= 0) {
+				return otp_read(bnum);
+			}
+
+		} else if (!strcmp(cmd, "write") && argc == 5) {
+			int bnum = getblocknum(2);
+			uint32_t expectedcrc = strtol(argv[4], NULL, 16);
+
+			if (bnum >= 0) {
+				return otp_write(bnum, argv[3], expectedcrc);
+			}
+
+		} else if (!strcmp(cmd, "lock") && argc == 4) {
+			int bnum = getblocknum(2);
+			int bnum2 = getblocknum(3);
+
+			if (bnum >= 0 && bnum == bnum2) {
+				otp_lock(bnum);
+				printf("LOCKED\n");
+				return 0;
+
+			} else {
+				printf("FAILED\n");
+				return 1;
+			}
+
+		} else {
+			usage("Invalid arguments");
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
<pre>
nsh> otp
otp: usage:
otp show - show all block contents and lock bitsotp write <blocknum> <32 hex bytes, LSB first, no spaces> <crc32 for bytes> - will print values after readback
otp read <blocknum> - will print 32 bytes readback from block (and the current CRC)
otp lock <blocknum> <blocknum> - will permanently lock the specified block number

nsh> otp show
 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
10: U 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
11: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6

nsh> otp write 10 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
otp: Write not accepted

nsh> otp write 10 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea67
otp: CRC does not match bytes

nsh> otp write 11 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
WRITTEN

nsh> otp write 11 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
WRITTEN

nsh> otp show
 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
10: U 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
11: U 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6

nsh> otp lock 10
otp: Invalid arguments
otp: usage:
otp show - show all block contents and lock bitsotp write <blocknum> <32 hex bytes, LSB first, no spaces> <crc32 for bytes> - will print values after readback
otp read <blocknum> - will print 32 bytes readback from block (and the current CRC)
otp lock <blocknum> <blocknum> - will permanently lock the specified block number

nsh> otp lock 10 10
LOCKED

nsh> otp show
 0: L 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
 1: L 3296c91156c6a2cd9d472bd768e74ad9c731d43b9180a994f9b927517e41425a e50fcf15
 2: L 5207fe5842dd9bcd27f2077759ca977292334e8c366969f3797efaaa6940ad00 26df18c8
 3: L c0190f185410e5fd13dce5b37b8f8030ab84e1fa1c026088eb1ee4b224fb662b ae616df5
 4: L a800a8110a956c55fe43698fa584e9a1d7f8b10495e3460c1de681c0c7b89875 3245288a
 5: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 6: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 7: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 8: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
 9: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
10: L 5058340000002600001000000000000000000000000000000000000000000000 2fab057d
11: U 5058340000ac26000010000000ffffffffffffffffffffffffffffffffffffff 55393c7b
12: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
13: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
14: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
15: U ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff e666fea6
nsh>
</pre>