### PR TITLE
PX4FMU::sensor_reset method fix

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1364,6 +1364,10 @@ PX4FMU::sensor_reset(int ms)
 	stm32_gpiowrite(GPIO_SPI_CS_BARO, 1);
 	stm32_gpiowrite(GPIO_SPI_CS_MPU, 1);
 
+	stm32_configgpio(GPIO_SPI1_SCK);
+	stm32_configgpio(GPIO_SPI1_MISO);
+	stm32_configgpio(GPIO_SPI1_MOSI);
+
 	// // XXX bring up the EXTI pins again
 	// stm32_configgpio(GPIO_GYRO_DRDY);
 	// stm32_configgpio(GPIO_MAG_DRDY);


### PR DESCRIPTION
Now it restore ok MOSI/MISO/SCK signals after rest performed.
Without this fix the 'fmu sensor_rest' command make I2C communications broken.
Fix has been tested, it works.

It has been implemented during investigation of BAD ACCEL HEALTH problem. I can see you have it already applied to master branch, but not to Copter-3.3 branch. 
https://github.com/diydrones/PX4Firmware/blame/master/src/drivers/px4fmu/fmu.cpp#L1495-L1497

It is an important fix to resolve BAD ACCEL HEALTH in Copter-3.3.

Details are here: http://diydrones.com/forum/topics/solution-proposal-for-pixhawk-imu2-related-bad-accell-health

Also it has been discussed with Lorenz Meier here: https://groups.google.com/forum/#!msg/px4users/Ek8D5hRZeIs/dWvDyZs-BAAJ

Thank you in advance,
Dmitry Prokhorov