### PR TITLE
ms5611: Fix to start drivers for all devices present at boot.

### DIFF
--- a/src/drivers/ms5611/ms5611_nuttx.cpp
+++ b/src/drivers/ms5611/ms5611_nuttx.cpp
@@ -963,7 +963,7 @@ start(enum MS5611_BUS busid)
 			continue;
 		}
 
-		started = started || start_bus(bus_options[i]);
+		started = started | start_bus(bus_options[i]);
 	}
 
 	if (!started) {


### PR DESCRIPTION
Short circuit evaluation was causing driver to start for only the first device detected.